### PR TITLE
feat:[최재민] 강아지 정보 게시판 관리를 위한 초기 엔티티 설계[Mung-process1]

### DIFF
--- a/springServer/src/main/java/com/example/mungmung/mungWiki/entity/DogStatus.java
+++ b/springServer/src/main/java/com/example/mungmung/mungWiki/entity/DogStatus.java
@@ -1,0 +1,33 @@
+package com.example.mungmung.mungWiki.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@NoArgsConstructor
+@Getter
+@Setter
+public class DogStatus {
+
+    @Id
+    @Column(name = "status_id", nullable = false)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long intelligenceLevel;
+
+    @Column(nullable = false)
+    private Long sheddingLevel;
+
+    @Column(nullable = false)
+    private Long sociabilityLevel;
+
+    @Column(nullable = false)
+    private Long activityLevel;
+
+    @Column(nullable = false)
+    private Long indoorAdaptLevel;
+}

--- a/springServer/src/main/java/com/example/mungmung/mungWiki/entity/DogType.java
+++ b/springServer/src/main/java/com/example/mungmung/mungWiki/entity/DogType.java
@@ -1,0 +1,49 @@
+package com.example.mungmung.mungWiki.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Arrays;
+
+@Getter
+@RequiredArgsConstructor
+public enum DogType {
+    POODLE("푸들"),
+    SHIH_TZU("시츄"),
+    BICHON_FRIZE("비숑프리제"),
+    POMERANIAN("포메라니안"),
+    MALTESE("말티즈"),
+    YORKSHIRE_TERRIER("요크셔테리어"),
+    CHIHUAHUA("치와와"),
+    DACHSHUND("닥스훈트"),
+    GOLDEN_RETRIEVER("골든리트리버"),
+    LABRADOR_RETRIEVER("래브라도리트리버"),
+    SIBERIAN_HUSKY("시베리안허스키"),
+    ALASKAN_MALAMUTE("알래스칸말라뮤트"),
+    SAMOYED("사모예드"),
+    MINIATURE_SCHNAUZER("미니어쳐슈나우저"),
+    BICHON("비숑"),
+    BOSTON_TERRIER("보스턴 테리어"),
+    BEAGLE("비글"),
+    SHETLAND_SHEEPDOG("셰틀랜드 쉽독"),
+    STANDARD_POODLE("스탠더드 푸들"),
+    SHIBA("시바"),
+    WELSH_CORGI("윌시 코기"),
+    JINDO("진돗개"),
+    GREYHOUND("그레이 하운드"),
+    AMERICAN_COCKER_SPANIEL("아메리칸 코카스파니엘"),
+    SPITZ("스피치"),
+    BULLDOG("불도그"),
+    MIX("믹스"),
+    ETC("기타");
+
+    final private String dogType;
+
+    public static DogType valueOfPaymentState(String dogType) {
+        return Arrays.stream(values())
+                .filter(value -> value.dogType.equals(dogType))
+                .findAny()
+                .orElse(null);
+    }
+
+}

--- a/springServer/src/main/java/com/example/mungmung/mungWiki/entity/MungWiki.java
+++ b/springServer/src/main/java/com/example/mungmung/mungWiki/entity/MungWiki.java
@@ -1,0 +1,31 @@
+package com.example.mungmung.mungWiki.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@NoArgsConstructor
+@Getter
+public class MungWiki {
+
+    @Id
+    @Column(name = "wiki_Id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long Id;
+
+    @Column(nullable = false)
+    private DogType dogType;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    private WikiDocument wikiDocument;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    private MungWiki mungWiki;
+
+    @OneToMany(fetch = FetchType.LAZY)
+    private List<WikiImages> wikiImages= new ArrayList<>();
+}

--- a/springServer/src/main/java/com/example/mungmung/mungWiki/entity/WikiDocument.java
+++ b/springServer/src/main/java/com/example/mungmung/mungWiki/entity/WikiDocument.java
@@ -1,0 +1,19 @@
+package com.example.mungmung.mungWiki.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor
+@Getter
+public class WikiDocument {
+
+    @Id
+    @Column(name = "Document_Id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long Id;
+
+    @Column(nullable = false)
+    private String document;
+}

--- a/springServer/src/main/java/com/example/mungmung/mungWiki/entity/WikiImages.java
+++ b/springServer/src/main/java/com/example/mungmung/mungWiki/entity/WikiImages.java
@@ -1,0 +1,28 @@
+package com.example.mungmung.mungWiki.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@NoArgsConstructor
+@Getter
+@Setter
+public class WikiImages {
+
+    @Id
+    @Column(name = "Wiki_Image_Id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long Id;
+
+    @Column
+    private String originalImageName;
+
+    @Column
+    private String uploadImageName;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "wiki_Id")
+    private MungWiki mungWiki;
+}

--- a/springServer/src/main/java/com/example/mungmung/mungWiki/repository/DogStatusRepository.java
+++ b/springServer/src/main/java/com/example/mungmung/mungWiki/repository/DogStatusRepository.java
@@ -1,0 +1,7 @@
+package com.example.mungmung.mungWiki.repository;
+
+import com.example.mungmung.mungWiki.entity.DogStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DogStatusRepository extends JpaRepository<DogStatus,Long> {
+}

--- a/springServer/src/main/java/com/example/mungmung/mungWiki/repository/MungWikiRepository.java
+++ b/springServer/src/main/java/com/example/mungmung/mungWiki/repository/MungWikiRepository.java
@@ -1,0 +1,7 @@
+package com.example.mungmung.mungWiki.repository;
+
+import com.example.mungmung.mungWiki.entity.MungWiki;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MungWikiRepository extends JpaRepository<MungWiki,Long> {
+}

--- a/springServer/src/main/java/com/example/mungmung/mungWiki/repository/WikiDocumentRepository.java
+++ b/springServer/src/main/java/com/example/mungmung/mungWiki/repository/WikiDocumentRepository.java
@@ -1,0 +1,7 @@
+package com.example.mungmung.mungWiki.repository;
+
+import com.example.mungmung.mungWiki.entity.WikiDocument;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface WikiDocumentRepository extends JpaRepository<WikiDocument,Long> {
+}

--- a/springServer/src/main/java/com/example/mungmung/mungWiki/repository/WikiImagesRepository.java
+++ b/springServer/src/main/java/com/example/mungmung/mungWiki/repository/WikiImagesRepository.java
@@ -1,0 +1,7 @@
+package com.example.mungmung.mungWiki.repository;
+
+import com.example.mungmung.mungWiki.entity.WikiImages;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface WikiImagesRepository extends JpaRepository<WikiImages,Long> {
+}


### PR DESCRIPTION
- [x]  기본적인 기본 정보를 다루는 객체 mungWiki 엔티티 제작
- [x]  강아지들의 사진 리스트를 담을 수 있는 객체 생성,  ManyToOne 매핑
- [x]  강아지들의 간단한 능력 정보를 담을 수 있는 객체 생성 및 OneToOne 매핑
- [x]  강아지 종류를 다루는 enum 객체 생성
- [x]  각 엔티티들의 jpa 쿼리문 작성을 위한 패키지 생성